### PR TITLE
Feat/setup load balancer

### DIFF
--- a/scripts/deploy_lb.py
+++ b/scripts/deploy_lb.py
@@ -1,0 +1,98 @@
+#!/usr/bin/env python3
+import json, os, sys, subprocess, base64, time
+
+KEY_PATH = os.getenv("AWS_KEY_PATH")
+if not KEY_PATH:
+    sys.exit("Missing AWS_KEY_PATH")
+
+SSH_OPTS = [
+    "ssh", "-o", "StrictHostKeyChecking=no", "-o", "BatchMode=yes",
+    "-o", "ServerAliveInterval=15", "-o", "ConnectTimeout=30"
+]
+
+def ssh(host, cmd):
+    return subprocess.run(
+        SSH_OPTS + ["-i", KEY_PATH, f"ubuntu@{host}", f"bash -lc '{cmd}'"],
+        stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True, check=True
+    )
+
+def scp_path(host, local_path):
+    subprocess.run(
+        ["scp", "-o", "StrictHostKeyChecking=no", "-i", KEY_PATH, "-r", local_path, f"ubuntu@{host}:~"],
+        stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True, check=True
+    )
+
+with open("artifacts/instances.json") as f:
+    instances = json.load(f)
+with open("artifacts/lb.json") as f:
+    lb = json.load(f)
+
+print("Waiting 60 seconds for the new instance to initialize its SSH service...")
+time.sleep(60)
+HOST = lb["public_ip"]
+targets = {
+    "cluster1": [f"http://{i['private_ip']}:8000/cluster1" for i in instances if i.get("cluster")=="cluster1"],
+    "cluster2": [f"http://{i['private_ip']}:8000/cluster2" for i in instances if i.get("cluster")=="cluster2"],
+}
+
+print(f"Deploying LB to {HOST}...")
+
+try:
+    print(f"[{HOST}] Waiting for cloud-init to finish (max 2 mins)...")
+    ssh(HOST, "sudo cloud-init status --wait")
+
+    print(f"[{HOST}] Installing Python dependencies...")
+    ssh(HOST, "sudo apt-get update -y && sudo DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends python3-pip")
+    ssh(HOST, "python3 -m pip install --upgrade pip fastapi uvicorn httpx")
+
+    print(f"[{HOST}] Copying lb/ source code...")
+    scp_path(HOST, "lb")
+
+    print(f"[{HOST}] Writing /etc/lb/targets.json configuration...")
+    targets_b64 = base64.b64encode(json.dumps(targets).encode("utf-8")).decode("ascii")
+    ssh(HOST, f"sudo mkdir -p /etc/lb && sudo touch /etc/lb/targets.json && echo '{targets_b64}' | base64 -d | sudo tee /etc/lb/targets.json >/dev/null")
+
+  
+
+    print(f"[{HOST}] Creating and starting systemd service for the LB...")
+    SERVICE_TPL = """[Unit]
+Description=Custom Latency-based LB
+After=network.target
+
+[Service]
+User=ubuntu
+WorkingDirectory=/home/ubuntu/lb
+Environment=LB_CONFIG=/etc/lb/targets.json
+AmbientCapabilities=CAP_NET_BIND_SERVICE
+CapabilityBoundingSet=CAP_NET_BIND_SERVICE
+ExecStart=/usr/bin/python3 -m uvicorn lb:app --host 0.0.0.0 --port 80
+Restart=always
+RestartSec=2
+
+[Install]
+WantedBy=multi-user.target
+"""
+    unit_b64 = base64.b64encode(SERVICE_TPL.encode("utf-8")).decode("ascii")
+    ssh(
+        HOST,
+        f"echo '{unit_b64}' | base64 -d | sudo tee /etc/systemd/system/lb.service >/dev/null && "
+        "sudo systemctl daemon-reload && "
+        "sudo systemctl enable --now lb"
+    )
+
+    print(f"[{HOST}] Waiting for LB service to become ready...")
+    ssh(
+        HOST,
+        "for i in $(seq 1 30); do "
+        "curl -s -o /dev/null http://127.0.0.1/status && echo 'READY' && exit 0; "
+        "sleep 1; "
+        "done; echo 'NOT READY'; exit 1"
+    )
+
+    print("✅ LB deployed.")
+
+except subprocess.CalledProcessError as e:
+    print(f"\n❌ FAILED during LB deployment on host {HOST}.")
+    print(f"  - Command exited with code: {e.returncode}")
+    print(f"  - Output:\n{e.stdout}")
+    sys.exit(1)

--- a/scripts/provision_lb.py
+++ b/scripts/provision_lb.py
@@ -1,0 +1,93 @@
+#!/usr/bin/env python3
+import json, os, sys, time, urllib.request
+import boto3
+from botocore.exceptions import ClientError
+
+REGION = os.getenv("AWS_REGION", "us-east-1")
+VPC_ID = os.getenv("AWS_VPC_ID")
+SUBNETS = os.getenv("AWS_SUBNET_IDS", "").split(",") if os.getenv("AWS_SUBNET_IDS") else []
+KEY = os.getenv("AWS_KEY_NAME")
+AMI = os.getenv("AWS_AMI_ID")
+INST_SG = os.getenv("AWS_INSTANCE_SG_ID")
+
+if not (VPC_ID and SUBNETS and KEY and AMI and INST_SG):
+    sys.exit("Missing one of: AWS_VPC_ID, AWS_SUBNET_IDS, AWS_KEY_NAME, AWS_AMI_ID, AWS_INSTANCE_SG_ID")
+
+ec2 = boto3.client("ec2", region_name=REGION)
+ec2r = boto3.resource("ec2", region_name=REGION)
+
+def ensure_sg(name, desc):
+    try:
+        r = ec2.describe_security_groups(
+            Filters=[{"Name":"vpc-id","Values":[VPC_ID]}, {"Name":"group-name","Values":[name]}]
+        )
+        if r["SecurityGroups"]:
+            sg_id = r["SecurityGroups"][0]["GroupId"]
+            print(f"Found existing security group '{name}' with ID: {sg_id}")
+            return sg_id
+    except ClientError:
+        pass
+    print(f"Creating new security group '{name}'...")
+    r = ec2.create_security_group(
+        GroupName=name, Description=desc, VpcId=VPC_ID
+    )
+    return r["GroupId"]
+
+def authorize_ingress(group_id, **kwargs):
+    try:
+        ec2.authorize_security_group_ingress(GroupId=group_id, IpPermissions=[kwargs])
+    except ClientError as e:
+        if e.response["Error"]["Code"] != "InvalidPermission.Duplicate":
+            raise
+
+print("Ensuring LB security group 'lab-lb' exists and is configured...")
+LB_SG = ensure_sg("lab-lb", "Custom LB SG")
+
+# Rule 1: Allow HTTP traffic from anyone to the LB
+print(f"  - Authorizing inbound HTTP (port 80) from 0.0.0.0/0 on SG {LB_SG}")
+authorize_ingress(LB_SG, IpProtocol="tcp", FromPort=80, ToPort=80, IpRanges=[{"CidrIp": "0.0.0.0/0"}])
+
+# Rule 2: Allow SSH traffic from YOUR IP to the LB for deployment
+try:
+    my_ip = urllib.request.urlopen('https://checkip.amazonaws.com', timeout=5).read().decode('utf8').strip()
+    print(f"  - Authorizing inbound SSH (port 22) from your IP ({my_ip}) on SG {LB_SG}")
+    authorize_ingress(LB_SG, IpProtocol="tcp", FromPort=22, ToPort=22, IpRanges=[{"CidrIp": f"{my_ip}/32"}])
+except Exception as e:
+    print(f"⚠️  Could not determine public IP to allow SSH. You may need to add a rule for port 22 manually. Error: {e}")
+
+# Rule 3: Allow app instances to receive traffic from the LB
+print(f"  - Authorizing inbound traffic on port 8000 from LB SG ({LB_SG}) on App SG ({INST_SG})")
+authorize_ingress(INST_SG, IpProtocol="tcp", FromPort=8000, ToPort=8000, UserIdGroupPairs=[{"GroupId": LB_SG}])
+
+print("\nLaunching LB instance (t2.large, Ubuntu 22.04)...")
+inst_list = ec2r.create_instances(
+    ImageId=AMI, InstanceType="t2.large", MinCount=1, MaxCount=1,
+    KeyName=KEY,
+    NetworkInterfaces=[{
+        "DeviceIndex": 0,
+        "SubnetId": SUBNETS[0],
+        "AssociatePublicIpAddress": True,
+        "Groups": [LB_SG],
+    }],
+    TagSpecifications=[{
+        "ResourceType":"instance",
+        "Tags":[{"Key":"Name","Value":"lab-lb-instance"}, {"Key":"Role","Value":"lb"}]
+    }]
+)
+inst = inst_list[0]
+
+print(f"Waiting for LB instance {inst.id} to start...")
+inst.wait_until_running()
+inst.load()
+
+data = {
+  "id": inst.id,
+  "public_ip": inst.public_ip_address,
+  "private_ip": inst.private_ip_address,
+  "sg": LB_SG
+}
+os.makedirs("artifacts", exist_ok=True)
+with open("artifacts/lb.json","w") as f:
+    json.dump(data, f, indent=2)
+
+print(f"✅ LB instance ready: {data['public_ip']} (ID: {data['id']})")


### PR DESCRIPTION
This PR introduces two scripts that fully automate standing up the latency-based load balancer (LB) environment.

**What's included**
- `provision_lb.py`: provisions a new EC2 instance for the LB
  - Ensures a dedicated security group for the LB (`lab-lb`)
  - Adds ingress rules for HTTP (80), SSH (22 from the operator's IP), and app traffic (8000 from LB to app SG)
  - Launches a t2.large Ubuntu 22.04 instance and writes metadata to `artifacts/lb.json`
- `deploy_lb.py`: deploys the FastAPI load balancer onto the provisioned instance
  - Waits for SSH and cloud-init
  - Installs Python dependencies (FastAPI, Uvicorn, httpx)
  - Copies the `lb/` source code
  - Writes `/etc/lb/targets.json` based on `instances.json`
  - Creates and enables a systemd service for the LB
  - Verifies readiness via `/status`

**Why**
These scripts automate the manual steps of setting up and deploying the load balancer, reducing human error and ensuring consistent, repeatable deployments.
